### PR TITLE
Restore valid lodash 4.17.21 entries in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9166,9 +9166,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -20869,9 +20869,9 @@
       }
     },
     "lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",


### PR DESCRIPTION
### Motivation

- Fix an invalid `lodash` lockfile entry (4.18.1) that referenced a non-published tarball and broken integrity metadata so installs and audits work reliably.

### Description

- Replaced the bogus `lodash` 4.18.1 metadata with the published `4.17.21` release in both `node_modules/lodash` and the top-level `lodash` sections of `package-lock.json`, updating `version`, `resolved`, and `integrity` fields.
- No changes were made to `package.json` or runtime source files; the change only normalizes the lockfile to match the existing dependency graph.
- Committed the fix on the current `work` branch with the message `Fix invalid lodash lockfile entry` (commit `1932b8d`).

### Testing

- Ran `npm install --package-lock-only --offline` which completed successfully and produced no vulnerabilities when combined with cached advisory data.
- Ran `npm audit --offline --json` which reported `0` vulnerabilities using the local advisory cache, while `npm audit --json` against the registry failed with HTTP `403` due to environment/registry access restrictions.
- Ran `npm run build` which completed successfully (compiled with pre-existing ESLint and Browserslist warnings), and `CI=true npm test -- --watchAll=false` which failed due to an unrelated starter test expecting the removed "Learn React" link.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76f4f49a00832e9789263d365bf578)